### PR TITLE
MNT: Make software admin highest prio

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
-.github/** @pcdshub/software-admin
-
 # Default owners are pcds-platforms-development
 * @robert-test-tk
 
 *.txt @tangkong
 
 *.py @ZLLentz
+
+.github/** @pcdshub/software-admin


### PR DESCRIPTION
So we can test if this team is allowed to be called as a codeowner reviewer

Last is highest priority

So before this PR, admin team always loses on priority to default (robert-test-tk)