### PR TITLE
Mnt more codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # Default owners are pcds-platforms-development
 * @robert-test-tk
 
-*.txt @tangkong
+*.txt @tangkong @pcdshub/shell-reviewers
 
-*.py @ZLLentz
+*.py @ZLLentz @pcdshub/python-reviewers
 
 .github/** @pcdshub/software-admin

--- a/project_name/tests/conftest.py
+++ b/project_name/tests/conftest.py
@@ -1,0 +1,1 @@
+# A python edit


### PR DESCRIPTION
## Description
Add other groups as code owners

## Motivation and Context
It seems like you have to manually add all-repository write for codeowners to be selectable.  If they do not have this their review will not be requested.

## How Has This Been Tested?
This is the setup to a test

## Where Has This Been Documented?
This PR